### PR TITLE
feat: Score에 리더보드 생성

### DIFF
--- a/components/Score.jsx
+++ b/components/Score.jsx
@@ -1,4 +1,59 @@
+import { useState } from "react";
+import './Score_style.css';
 export const ScoreBoard=()=>{
-return <>Score</>
+
+    const [Player,setPlayer] = useState([  /* Player 정보가 담긴 배열 */
+        { rank: 1, name: 'Name', score: 1500, date: '2024-00-00'},
+        { rank: 2, name: 'Name', score: 1400, date: '2024-00-00'},
+        { rank: 3, name: 'Name', score: 1300, date: '2024-00-00'},
+        { rank: 4, name: 'Name', score: 1200, date: '2024-00-00'},
+        { rank: 5, name: 'Name', score: 1100, date: '2024-00-00'},
+        { rank: 6, name: 'Name', score: 1000, date: '2024-00-00'},
+        { rank: 7, name: 'Name', score: 900, date: '2024-00-00'},
+        { rank: 8, name: 'Name', score: 800, date: '2024-00-00'},
+        { rank: 9, name: 'Name', score: 700, date: '2024-00-00'},
+        
+    ]);
+    
+
+return <>
+    <div className="leaderBoard">
+                <h1>RANKING</h1>
+                <table>
+                    <thead>
+                        <tr> 
+                            <th>RANK</th>  {/* 순위표 attribute */}
+                            <th>PLAYER</th>
+                            <th>SCORE</th>
+                            <th>DATE</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {Player.map(p => (  /*Player 배열을 p로 탐색하기, rank를 키로 정함*/
+                            <tr key={p.rank}> 
+                                <td>{p.rank}{단위(p.rank)}</td>
+                                <td>{p.name}</td>
+                                <td>{p.score}</td>
+                                <td>{p.date}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+</>
+ function 단위(rank){/*등수에 맞는 단위를 붙여주는 함수*/
+    switch (rank) {
+        case 1:
+            return "st";
+        case 2:
+            return "nd";
+        case 3:
+            return "rd";
+        default:
+            return "th";
+    }
+}
 
 }
+
+ 

--- a/components/Score_style.css
+++ b/components/Score_style.css
@@ -1,0 +1,37 @@
+h1{
+    font-family: 'PixelBold', sans-serif;
+    font-size: 100px;
+    text-align: center;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    color: black; 
+}
+table {
+    width: 80%;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 10px;
+    background-color: black;
+}
+thead{
+    background-color: #4f4f4f;
+    color: #ffffff;
+}
+th{
+    font-family: "PixelSemiBold";
+    padding: 10px;
+    text-align: center;
+    font-size: 30px;
+    color: #ffffff;
+}
+td{
+    font-family: "PixelRegular";
+    padding: 10px;
+    text-align: center;
+    font-size: 25px;
+    color: #ffffff;
+}
+ 
+tbody tr:hover {
+    background-color: grey;
+}


### PR DESCRIPTION
Score.jsx 수정, Score_style.css 파일 추가하여 리더보드를 만들었습니다.

플레이어의 이름, 점수, 플레이한 날짜를 보여줍니다. 

![스크린샷 2024-05-30 231200](https://github.com/fghy788/OpenSource-9/assets/119734946/e1751bfd-7e70-47fa-a7cf-f6dc58cf5e90)

